### PR TITLE
Allow client to specify the API version and fix call to getCurrentProfile

### DIFF
--- a/spec/vso-client.spec.js
+++ b/spec/vso-client.spec.js
@@ -44,6 +44,12 @@ describe('VSO Client Tests', function(){
       should.exist(clientOAuth.clientSPS)
   });
 
+  it('should have overriden version', function () {
+      var version = "1.0-preview-unitTest"
+      clientWithVersion = Client.createClient(url, collection, username, password, { apiVersion: version } );
+
+      clientWithVersion.apiVersion.should.equal(version);      
+  });
 
   it ( 'should return a field by name', function() {
     var field = client.findItemField(fields, 'System.Rev');


### PR DESCRIPTION
The client can now specify the version of the API it wants to use
  The parameter can be defined in the createXXXX methods or using the setVersion method of vso-client
